### PR TITLE
chore: rebrand AdminBro to AdminJS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,6 +158,6 @@ dist
 
 types
 build
-.adminbro
+.adminjs
 
 example-app/cypress/videos

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is an official [AdminJS](https://github.com/SoftwareBrothers/adminjs) plugi
 
 AdminJS is an automatic admin interface which can be plugged into your application. You, as a developer, provide database models (like posts, comments, stores, products or whatever else your application uses), and AdminJS generates UI which allows you (or other trusted users) to manage content.
 
-Check out the example application with mongo and postgres models here: https://admin-bro-example-app-staging.herokuapp.com/admin
+Check out the example application with mongo and postgres models here: https://demo.adminjs.co/admin
 
 Or visit [AdminJS](https://github.com/SoftwareBrothers/adminjs) github page.
 

--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
-# NestJS plugin for AdminBro
+# NestJS plugin for AdminJS
 
-This is an official [AdminBro](https://github.com/SoftwareBrothers/admin-bro) plugin which integrates it to [nestjs](https://nestjs.com) framework.
+This is an official [AdminJS](https://github.com/SoftwareBrothers/adminjs) plugin which integrates it to [nestjs](https://nestjs.com) framework.
 
-## AdminBro
+## AdminJS
 
-AdminBro is an automatic admin interface which can be plugged into your application. You, as a developer, provide database models (like posts, comments, stores, products or whatever else your application uses), and AdminBro generates UI which allows you (or other trusted users) to manage content.
+AdminJS is an automatic admin interface which can be plugged into your application. You, as a developer, provide database models (like posts, comments, stores, products or whatever else your application uses), and AdminJS generates UI which allows you (or other trusted users) to manage content.
 
 Check out the example application with mongo and postgres models here: https://admin-bro-example-app-staging.herokuapp.com/admin
 
-Or visit [AdminBro](https://github.com/SoftwareBrothers/admin-bro) github page.
+Or visit [AdminJS](https://github.com/SoftwareBrothers/adminjs) github page.
 
 ## Usage
 
-To see example usage see the [example-app](https://github.com/SoftwareBrothers/admin-bro-nestjs/tree/master/example-app) or visit the [Nestjs section under AdminBro project page](https://softwarebrothers.github.io/admin-bro-dev/module-admin-bro-nest.html)
+To see example usage see the [example-app](https://github.com/SoftwareBrothers/adminjs-nestjs/tree/master/example-app) or visit the [Nestjs section under AdminJS project page](https://softwarebrothers.github.io/adminjs-dev/module-adminjs-nest.html)
 
 ## License
 
-AdminBro is Copyright © 2020 SoftwareBrothers.co. It is free software, and may be redistributed under the terms specified in the [LICENSE](LICENSE.md) file.
+AdminJS is Copyright © 2020 SoftwareBrothers.co. It is free software, and may be redistributed under the terms specified in the [LICENSE](LICENSE.md) file.
 
 ## About SoftwareBrothers.co
 

--- a/example-app/package.json
+++ b/example-app/package.json
@@ -18,13 +18,13 @@
     "test:e2e": "NODE_ENV=test jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
-    "@admin-bro/express": "^3.0.1",
-    "@admin-bro/mongoose": "^1.1.0",
+    "@adminjs/express": "^3.0.1",
+    "@adminjs/mongoose": "^1.1.0",
     "@nestjs/common": "^7.4.2",
     "@nestjs/core": "7.4.2",
     "@nestjs/mongoose": "^7.0.2",
     "@nestjs/platform-express": "^6.7.2",
-    "admin-bro": "^3.3.1",
+    "adminjs": "^3.3.1",
     "class-transformer": "^0.3.1",
     "class-validator": "^0.12.2",
     "express": "^4.17.1",

--- a/example-app/src/app.module.ts
+++ b/example-app/src/app.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
 import { MongooseModule, getModelToken } from '@nestjs/mongoose';
-import AdminBro from 'admin-bro';
-import AdminBroMongoose from '@admin-bro/mongoose';
+import AdminJS from 'adminjs';
+import AdminJSMongoose from '@adminjs/mongoose';
 import { Model } from 'mongoose';
 
 import { AdminModule } from '../../src'; // lib
@@ -12,7 +12,7 @@ import { ExpressCustomLoader } from './express-custom.loader';
 import { Admin } from './mongoose/admin-model';
 import { MongooseSchemasModule } from './mongoose/mongoose.module';
 
-AdminBro.registerAdapter(AdminBroMongoose);
+AdminJS.registerAdapter(AdminJSMongoose);
 
 @Module({
   imports: [
@@ -25,7 +25,7 @@ AdminBro.registerAdapter(AdminBroMongoose);
         getModelToken('Admin'),
       ],
       useFactory: (adminModel: Model<Admin>) => ({
-        adminBroOptions: {
+        adminJsOptions: {
           rootPath: '/admin',
           resources: [
             { resource: adminModel },

--- a/example-app/src/express-custom.loader.ts
+++ b/example-app/src/express-custom.loader.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-underscore-dangle */
-import AdminBro from 'admin-bro';
+import AdminJS from 'adminjs';
 import { Injectable } from '@nestjs/common';
 import { AbstractHttpAdapter } from '@nestjs/core';
 
@@ -10,7 +10,7 @@ import { ExpressLoader } from '../../src/loaders/express.loader';
 @Injectable()
 export class ExpressCustomLoader extends AbstractLoader {
   public register(
-    admin: AdminBro,
+    admin: AdminJS,
     httpAdapter: AbstractHttpAdapter,
     options: AdminModuleOptions,
   ) {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@semantic-release/git": "^9.0.0",
     "@typescript-eslint/eslint-plugin": "^3.7.0",
     "@typescript-eslint/parser": "^3.7.0",
-    "adminjs": "^3.3.1",
+    "adminjs": "^5.0.0",
     "eslint": "^7.5.0",
     "eslint-config-airbnb": "^18.2.0",
     "eslint-plugin-import": "^2.22.0",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@admin-bro/nestjs",
+  "name": "@adminjs/nestjs",
   "version": "1.1.0",
   "main": "build/index.js",
   "types": "types/index.d.ts",
   "private": false,
-  "repository": "git@github.com:SoftwareBrothers/admin-bro-nestjs.git",
+  "repository": "git@github.com:SoftwareBrothers/adminjs-nestjs.git",
   "license": "MIT",
   "scripts": {
     "release": "semantic-release",
@@ -18,7 +18,7 @@
     }
   },
   "peerDependencies": {
-    "admin-bro": ">=3.0.0"
+    "adminjs": ">=3.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^8.3.5",
@@ -26,7 +26,7 @@
     "@semantic-release/git": "^9.0.0",
     "@typescript-eslint/eslint-plugin": "^3.7.0",
     "@typescript-eslint/parser": "^3.7.0",
-    "admin-bro": "^3.3.1",
+    "adminjs": "^3.3.1",
     "eslint": "^7.5.0",
     "eslint-config-airbnb": "^18.2.0",
     "eslint-plugin-import": "^2.22.0",

--- a/src/admin.module.ts
+++ b/src/admin.module.ts
@@ -1,4 +1,4 @@
-import AdminBro from 'admin-bro'
+import AdminJS from 'adminjs'
 import { Module, DynamicModule, OnModuleInit, Inject } from '@nestjs/common'
 import { HttpAdapterHost } from '@nestjs/core'
 
@@ -10,14 +10,14 @@ import { AdminModuleFactory } from './interfaces/admin-module-factory.interface'
 import { CustomLoader } from './interfaces/custom-loader.interface'
 
 /**
- * Nest module which is responsible for an AdminBro integration
+ * Nest module which is responsible for an AdminJS integration
  * 
  * @summary Nest Module
  * 
  * @class
- * @name module:@admin-bro/nestjs~AdminModule
+ * @name module:@adminjs/nestjs~AdminModule
  * @alias AdminModule
- * @memberof module:@admin-bro/nestjs
+ * @memberof module:@adminjs/nestjs
  */
 // This is needed by JSDoc which cannot parse this statement
 @Module({})
@@ -33,12 +33,12 @@ export class AdminModule implements OnModuleInit {
    * Creates admin in a synchronous way
    * 
    * @param {AdminModuleOptions} options
-   * @memberof module:@admin-bro/nestjs~AdminModule
+   * @memberof module:@adminjs/nestjs~AdminModule
    * @method
    * @name createAdmin
    * @example
    * import { Module } from '@nestjs/common';
-   * import { AdminModule } from '@admin-bro/nestjs';
+   * import { AdminModule } from '@adminjs/nestjs';
    * 
    * \@Module({
    *   imports: [
@@ -72,7 +72,7 @@ export class AdminModule implements OnModuleInit {
    * Creates admin in an asynchronous way
    * 
    * @param {AdminModuleFactory} options
-   * @memberof module:@admin-bro/nestjs~AdminModule
+   * @memberof module:@adminjs/nestjs~AdminModule
    * @method
    * @name createAdminAsync
    * @example
@@ -87,7 +87,7 @@ export class AdminModule implements OnModuleInit {
    *         getModelToken('Admin'), // using mongoose function to inject dependency
    *       ],
    *       useFactory: (adminModel: Model<Admin>) => ({ // injected dependecy will appear as an argument
-   *         adminBroOptions: {
+   *         adminJsOptions: {
    *           rootPath: '/admin',
    *           resources: [
    *             { resource: adminModel },
@@ -119,19 +119,19 @@ export class AdminModule implements OnModuleInit {
   }
 
   /**
-   * Applies given options to AdminBro and initializes it
+   * Applies given options to AdminJS and initializes it
    */
   public onModuleInit() {
     if ('shouldBeInitialized' in this.adminModuleOptions && !this.adminModuleOptions.shouldBeInitialized) {
       return;
     }
 
-    const admin = new AdminBro(this.adminModuleOptions.adminBroOptions);
+    const admin = new AdminJS(this.adminModuleOptions.adminJsOptions);
 
     const { httpAdapter } = this.httpAdapterHost;
     this.loader.register(admin, httpAdapter, { 
       ...this.adminModuleOptions, 
-      adminBroOptions: admin.options,
+      adminJsOptions: admin.options,
     });
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,25 +1,25 @@
 /**
- * @module @admin-bro/nestjs
+ * @module @adminjs/nestjs
  * @subcategory Plugins
  * @section modules
  * 
  * @classdesc
- * This is an official plugin which allows you to render AdminBro in [NestJS
+ * This is an official plugin which allows you to render AdminJS in [NestJS
  * framework](https://nestjs.com/)
  * 
  * ## Installation
  * 
- * 1. First of all, install the AdminBro along with the module:
+ * 1. First of all, install the AdminJS along with the module:
  * 
  * ```
- * yarn add admin-bro @admin-bro/nestjs
+ * yarn add adminjs @adminjs/nestjs
  * ```
  * 
  * ### Express:
- * You have to additionally add admin-bro express plugin along with packages it's using, express and express formidable:
+ * You have to additionally add adminjs express plugin along with packages it's using, express and express formidable:
  * 
  * ```
- * yarn add express @admin-bro/express express-formidable
+ * yarn add express @adminjs/express express-formidable
  * ```
  * 
  * If you are passing `authenticate` object you have to also add express-session:
@@ -36,12 +36,12 @@
  * 
  * ```
  * import { Module } from '@nestjs/common';
- * import { AdminModule } from '@admin-bro/nestjs';
+ * import { AdminModule } from '@adminjs/nestjs';
  * 
  * \@Module({
  *   imports: [
  *     AdminModule.createAdmin({
- *       adminBroOptions: {
+ *       adminJsOptions: {
  *         rootPath: '/admin',
  *         resources: [],
  *       }),
@@ -51,25 +51,25 @@
  * export class AppModule {}
  * ```
  * 
- * Then enter `/admin` path in your browser and you should see the AdminBro.
+ * Then enter `/admin` path in your browser and you should see the AdminJS.
  * 
  * 3. Passing resources
  * 
  * Let say you use @nestjs/typeorm module, and you have users module.
  * 
- * - you have to install @admin-bro/typeorm adapter
- * - you have to register it in AdminBro (as stated in the docs)
+ * - you have to install @adminjs/typeorm adapter
+ * - you have to register it in AdminJS (as stated in the docs)
  * - and you have to pass it to your options
  * 
  * ```
- * import AdminBro from 'admin-bro';
+ * import AdminJS from 'adminjs';
  * import { Module } from '@nestjs/common';
- * import { AdminModule } from '@admin-bro/nestjs';
- * import { Database, Resource } from '@admin-bro/typeorm'
+ * import { AdminModule } from '@adminjs/nestjs';
+ * import { Database, Resource } from '@adminjs/typeorm'
  * import { TypeOrmModule } from '@nestjs/typeorm';
  * import { UsersModule } from './users/users.module';
  * 
- * AdminBro.registerAdapter({ Database, Resource })
+ * AdminJS.registerAdapter({ Database, Resource })
  * 
  * \@Module({
  *   imports: [
@@ -85,7 +85,7 @@
  *       synchronize: true,
  *     }),
  *     AdminModule.createAdmin({
- *       adminBroOptions: {
+ *       adminJsOptions: {
  *          rootPath: '/admin',
  *          resources: [User],
  *       }
@@ -97,7 +97,7 @@
  * 
  * ## Authentication
  * 
- * Apart from the `adminBroOptions` you can define `auth` settings.
+ * Apart from the `adminJsOptions` you can define `auth` settings.
  * 
  * This is an example which always logs users in, since authenticate method
  * always returns a Promise resolving to {@link CurrentAdmin}. You may
@@ -106,7 +106,7 @@
  * 
  * ```
  * AdminModule.createAdmin({
- *     adminBroOptions: {
+ *     adminJsOptions: {
  *       rootPath: '/admin',
  *       resources: [User],
  *     },
@@ -138,7 +138,7 @@
  * })
  * export class MongooseSchemasModule {} 
  * ```
- * - we want to use Admin model in admin-bro panel, to be displayed as the resource
+ * - we want to use Admin model in adminjs panel, to be displayed as the resource
  * ```
  * \@Module({
  *    imports: [
@@ -151,7 +151,7 @@
  *          getModelToken('Admin'), // using mongoose function to inject dependency
  *        ],
  *        useFactory: (adminModel: Model<Admin>) => ({ // injected dependecy will appear as an argument
- *          adminBroOptions: {
+ *          adminJsOptions: {
  *            rootPath: '/admin',
  *            resources: [
  *              { resource: adminModel },
@@ -166,9 +166,9 @@
  * ```
  * 
  * ## Custom loader
- * In most cases default plugins for admin-bro are enough for functionality we need, but in rare ocasions 
+ * In most cases default plugins for adminjs are enough for functionality we need, but in rare ocasions 
  * we want to customize routing, or achieve different logic after login and this cases can be achieved only
- * by providing own plugin implementation. Because @admin-bro/nestjs under the hood uses plugin for express (@admin-bro/express)
+ * by providing own plugin implementation. Because @adminjs/nestjs under the hood uses plugin for express (@adminjs/express)
  * it would require basically copying whole nestjs plugin and express plugin to own project to put any changes.
  * Instead there is optional parameter to put your custom loader if you don't want to use official one for any reason.
  * Your custom loader must extend AbstractLoader.
@@ -177,7 +177,7 @@
  * \@Injectable()
  * export class CustomLoader extends AbstractLoader {
  *   public register(
- *     admin: AdminBro,
+ *     admin: AdminJS,
  *     httpAdapter: AbstractHttpAdapter,
  *     options: AdminModuleOptions,
  *   ) {}
@@ -188,7 +188,7 @@
  * 
  * ```
  * AdminModule.createAdmin({
- *     adminBroOptions: {
+ *     adminJsOptions: {
  *       //...
  *     },
  *     auth: {
@@ -208,7 +208,7 @@
  * ```
  * 
  * ## Example
- * There is a working example [here](https://github.com/SoftwareBrothers/admin-bro-nestjs/tree/master/example-app)
+ * There is a working example [here](https://github.com/SoftwareBrothers/adminjs-nestjs/tree/master/example-app)
  */
 import * as NestJSPlugin from './admin.module'
 

--- a/src/interfaces/admin-module-options.interface.ts
+++ b/src/interfaces/admin-module-options.interface.ts
@@ -1,4 +1,4 @@
-import { AdminJsOptions, CurrentAdmin } from 'adminjs';
+import { AdminJSOptions, CurrentAdmin } from 'adminjs';
 import { SessionOptions } from 'express-session';
 
 import { ExpressFormidableOptions } from './express-formidable-options.interface';
@@ -13,7 +13,7 @@ export type AdminModuleOptions = {
   /**
    * Standard AdminJS options
    */
-  adminJsOptions: AdminJsOptions,
+  adminJsOptions: AdminJSOptions,
   /**
    * Authentication options. When NOT provided, it will initialize AdminJS without login page and authorization function. 
    */

--- a/src/interfaces/admin-module-options.interface.ts
+++ b/src/interfaces/admin-module-options.interface.ts
@@ -1,4 +1,4 @@
-import { AdminBroOptions, CurrentAdmin } from 'admin-bro';
+import { AdminJsOptions, CurrentAdmin } from 'adminjs';
 import { SessionOptions } from 'express-session';
 
 import { ExpressFormidableOptions } from './express-formidable-options.interface';
@@ -6,16 +6,16 @@ import { ExpressFormidableOptions } from './express-formidable-options.interface
 /**
  * Options passed to nestjs module
  * 
- * @memberof module:@admin-bro/nestjs
+ * @memberof module:@adminjs/nestjs
  * @alias AdminModuleOptions
  */
 export type AdminModuleOptions = {
   /**
-   * Standard AdminBro options
+   * Standard AdminJS options
    */
-  adminBroOptions: AdminBroOptions,
+  adminJsOptions: AdminJsOptions,
   /**
-   * Authentication options. When NOT provided, it will initialize AdminBro without login page and authorization function. 
+   * Authentication options. When NOT provided, it will initialize AdminJS without login page and authorization function. 
    */
   auth?: {
     /**
@@ -26,17 +26,17 @@ export type AdminModuleOptions = {
     cookieName: string,
   }
   /**
-   * Options passed to express formidable (used only by AdminBro express module)
+   * Options passed to express formidable (used only by AdminJS express module)
    */
   formidableOptions?: ExpressFormidableOptions,
   /**
-   * Options passed to express session (used only by AdminBro express module)
+   * Options passed to express session (used only by AdminJS express module)
    * Here you might want to change the store from the default memory store to
    * something more reliable (i.e. database).
    */
   sessionOptions?: SessionOptions,
   /**
-   * Flag indicating if admin-bro should be initialized. Helpful in cases like turning off admin for tests.
+   * Flag indicating if adminjs should be initialized. Helpful in cases like turning off admin for tests.
    * Default is true.
    */
   shouldBeInitialized?: boolean,

--- a/src/interfaces/custom-loader.interface.ts
+++ b/src/interfaces/custom-loader.interface.ts
@@ -4,8 +4,8 @@ import { AbstractLoader } from '../loaders/abstract.loader';
 
 export type CustomLoader = {
   /**
-   * In order not to use default Express (@admin-bro/express) or Fastify (not yet implemented) loader
-   * you can provide your own implementation of Loader that plugs in AdminBro.
+   * In order not to use default Express (@adminjs/express) or Fastify (not yet implemented) loader
+   * you can provide your own implementation of Loader that plugs in AdminJS.
    */
   customLoader?: Type<AbstractLoader>;
 };

--- a/src/loaders/abstract.loader.ts
+++ b/src/loaders/abstract.loader.ts
@@ -1,4 +1,4 @@
-import AdminBro from 'admin-bro';
+import AdminJS from 'adminjs';
 import { Injectable } from '@nestjs/common';
 import { AbstractHttpAdapter } from '@nestjs/core';
 
@@ -7,7 +7,7 @@ import { AdminModuleOptions } from '../interfaces/admin-module-options.interface
 @Injectable()
 export abstract class AbstractLoader {
   public abstract register(
-    admin: AdminBro,
+    admin: AdminJS,
     httpAdapter: AbstractHttpAdapter,
     options: AdminModuleOptions,
 

--- a/src/loaders/express.loader.ts
+++ b/src/loaders/express.loader.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-underscore-dangle */
-import AdminBro from 'admin-bro';
+import AdminJS from 'adminjs';
 import { Injectable } from '@nestjs/common';
 import { AbstractHttpAdapter } from '@nestjs/core';
 import { loadPackage } from '@nestjs/common/utils/load-package.util';
@@ -11,34 +11,34 @@ import { AbstractLoader } from './abstract.loader';
 @Injectable()
 export class ExpressLoader extends AbstractLoader {
   public register(
-    admin: AdminBro,
+    admin: AdminJS,
     httpAdapter: AbstractHttpAdapter,
     options: AdminModuleOptions,
   ) {
     const app = httpAdapter.getInstance();
 
-    loadPackage('express', '@admin-bro/nestjs');
-    const adminBroExpressjs = loadPackage('@admin-bro/express', '@admin-bro/nestjs', () =>
-      require('@admin-bro/express')
+    loadPackage('express', '@adminjs/nestjs');
+    const adminJsExpressjs = loadPackage('@adminjs/express', '@adminjs/nestjs', () =>
+      require('@adminjs/express')
     );
-    loadPackage('express-formidable', '@admin-bro/nestjs');
+    loadPackage('express-formidable', '@adminjs/nestjs');
 
     let router;
 
     if ('auth' in options) {
-      loadPackage('express-session', '@admin-bro/nestjs');
-      router = adminBroExpressjs.buildAuthenticatedRouter(
+      loadPackage('express-session', '@adminjs/nestjs');
+      router = adminJsExpressjs.buildAuthenticatedRouter(
         admin, options.auth, undefined, options.sessionOptions, options.formidableOptions
       );
     } else {
-      router = adminBroExpressjs.buildRouter(admin, undefined, options.formidableOptions);
+      router = adminJsExpressjs.buildRouter(admin, undefined, options.formidableOptions);
     }
 
     // This named function is there on purpose. 
     // It names layer in main router with the name of the function, which helps localize
     // admin layer in reorderRoutes() step.
     // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
-    app.use(options.adminBroOptions.rootPath, function admin(req, res, next) {
+    app.use(options.adminJsOptions.rootPath, function admin(req, res, next) {
       return router(req, res, next);
     });
     this.reorderRoutes(app);
@@ -49,8 +49,8 @@ export class ExpressLoader extends AbstractLoader {
     let urlencodedParser;
     let admin;
 
-    // Nestjs uses bodyParser under the hood which is in conflict with admin-bro setup.
-    // Due to admin-bro-expressjs usage of formidable we have to move body parser in layer tree after admin-bro init.
+    // Nestjs uses bodyParser under the hood which is in conflict with adminjs setup.
+    // Due to adminjs-expressjs usage of formidable we have to move body parser in layer tree after adminjs init.
     // Notice! This is not documented feature of express, so this may change in the future. We have to keep an eye on it.
     if (app && app._router && app._router.stack) {
       const jsonParserIndex = app._router.stack.findIndex(
@@ -74,7 +74,7 @@ export class ExpressLoader extends AbstractLoader {
         admin = app._router.stack.splice(adminIndex, 1)
       }
 
-      // if admin-bro-nestjs didn't reorder the middleware
+      // if adminjs-nestjs didn't reorder the middleware
       // the body parser would have come after corsMiddleware
       const corsIndex = app._router.stack.findIndex(
         (layer: { name: string }) => layer.name === 'corsMiddleware',

--- a/src/loaders/noop.loader.ts
+++ b/src/loaders/noop.loader.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-empty-function */
-import AdminBro from 'admin-bro';
+import AdminJS from 'adminjs';
 import { Injectable } from '@nestjs/common';
 import { AbstractHttpAdapter } from '@nestjs/core';
 
@@ -11,7 +11,7 @@ import { AbstractLoader } from './abstract.loader';
 @Injectable()
 export class NoopLoader extends AbstractLoader {
   public register(
-    admin: AdminBro,
+    admin: AdminJS,
     httpAdapter: AbstractHttpAdapter,
     options: AdminModuleOptions,
   ) {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "jsx": "react",
     "declaration": true,
     "declarationDir": "./types",
+    "skipLibCheck": true,
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
     "strictFunctionTypes": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,12 +2,13 @@
 # yarn lockfile v1
 
 
-"@admin-bro/design-system@^1.7.0":
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/@admin-bro/design-system/-/design-system-1.7.0.tgz#1a5f46bff89db7aba33367db9a84cf00ddaaea5c"
-  integrity sha512-pf+b/YkKoylvcg1wp1yUhbWv0e5MZHjKQdPqTt6UXutVgpqldimDv5be3i2avkqNSB5XrOXVZTIcW4vj0vy33g==
+"@adminjs/design-system@^2.0.0":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@adminjs/design-system/-/design-system-2.0.1.tgz#52468031ee34ffab117f60740924793aa22cce39"
+  integrity sha512-+lBuFGHPISWPC7O1DSEB4Eae3S+vrVS6LD+TZbVju6nvhIUnGZgc3DHv/wLtmTzHwwgnDsEwY7RRMatsN3zuBQ==
   dependencies:
     "@carbon/icons-react" "^10.14.0"
+    date-fns "2.15.0"
     jw-paginate "^1.0.4"
     lodash "^4.17.20"
     polished "^3.6.5"
@@ -951,10 +952,17 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.1.2", "@babel/runtime@^7.10.1", "@babel/runtime@^7.10.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.11.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.0.tgz#f10245877042a815e07f7e693faff0ae9d3a2aac"
   integrity sha512-qArkXsjJq7H+T86WrIFV0Fnu/tNOkZ4cgXmjkzAu3b/58D5mFIO8JH/y77t7C9q0OdDRdh9s7Ue5GasYssxtXw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.12.0", "@babel/runtime@^7.12.1":
+  version "7.14.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.6.tgz#535203bc0892efc7dec60bdc27b2ecf6e409062d"
+  integrity sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -1703,6 +1711,14 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
+"@types/hoist-non-react-statics@^3.3.0":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
 "@types/json-schema@^7.0.3":
   version "7.0.5"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.5.tgz#dcce4430e64b443ba8945f0290fb564ad5bac6dd"
@@ -1753,6 +1769,25 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
   integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
 
+"@types/react-redux@^7.1.16":
+  version "7.1.16"
+  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.16.tgz#0fbd04c2500c12105494c83d4a3e45c084e3cb21"
+  integrity sha512-f/FKzIrZwZk7YEO9E1yoxIuDNRiDducxkFlkw/GNMGEnK9n4K8wJzlJBghpSuOVDgEUHoDkDF7Gi9lHNQR4siw==
+  dependencies:
+    "@types/hoist-non-react-statics" "^3.3.0"
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+    redux "^4.0.0"
+
+"@types/react@*":
+  version "17.0.11"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.11.tgz#67fcd0ddbf5a0b083a0f94e926c7d63f3b836451"
+  integrity sha512-yFRQbD+whVonItSk7ZzP/L+gPTJVBkL/7shLEF+i9GC/1cV3JmUxEQz6+9ylhUpWSDuqo1N9qEvqS6vTj4USUA==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
 "@types/react@^16.9.16":
   version "16.9.43"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.43.tgz#c287f23f6189666ee3bebc2eb8d0f84bcb6cdb6b"
@@ -1772,6 +1807,11 @@
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
   integrity sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==
+
+"@types/scheduler@*":
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.1.tgz#18845205e86ff0038517aab7a18a62a6b9f71275"
+  integrity sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==
 
 "@types/serve-static@*":
   version "1.13.5"
@@ -1887,12 +1927,12 @@ acorn@^7.3.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.3.1.tgz#85010754db53c3fbaf3b9ea3e083aa5c5d147ffd"
   integrity sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==
 
-admin-bro@^3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/admin-bro/-/admin-bro-3.3.1.tgz#ef7710310f80b0c945fbb1dff49c6b2359c9a882"
-  integrity sha512-ObdiPDMA8u89U35fwRHxSaje2zBjPqkKlT+6oN80HIRdkQImQ+51hEU5YaQ/EEzWFQGqGYuSxAhkFtXY6ZLjhg==
+adminjs@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/adminjs/-/adminjs-5.0.0.tgz#335021b4cef136efaa8d75e41db43c806a8eee35"
+  integrity sha512-kedIkWX+83XaU9sQAM5TcYUxPNrat1J8cafC4O9gJhz1//bFz53hWCUsLtRhZuDDVvoKXGZ18h7tlbcG5MQJGg==
   dependencies:
-    "@admin-bro/design-system" "^1.7.0"
+    "@adminjs/design-system" "^2.0.0"
     "@babel/core" "^7.10.2"
     "@babel/parser" "^7.10.2"
     "@babel/plugin-transform-runtime" "^7.10.1"
@@ -1907,15 +1947,16 @@ admin-bro@^3.3.1:
     "@rollup/plugin-node-resolve" "^9.0.0"
     "@rollup/plugin-replace" "^2.3.3"
     "@types/react" "^16.9.16"
-    axios "^0.19.2"
+    axios "^0.21.1"
     babel-plugin-styled-components "^1.11.1"
     commander "^5.1.0"
     flat "^4.1.0"
-    i18next "^19.1.0"
+    i18next "19.8.7"
     lodash "^4.17.11"
     ora "^4.0.2"
     prop-types "^15.7.2"
     react "=16.13.1"
+    react-beautiful-dnd "^13.0.0"
     react-dom "=16.13.1"
     react-i18next "^11.3.1"
     react-is "=16.13.1"
@@ -2185,12 +2226,19 @@ axe-core@^3.5.4:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.5.5.tgz#84315073b53fa3c0c51676c588d59da09a192227"
   integrity sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q==
 
-axios@0.19.2, axios@^0.19.2:
+axios@0.19.2:
   version "0.19.2"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
   integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
   dependencies:
     follow-redirects "1.5.10"
+
+axios@^0.21.1:
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
+  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
+  dependencies:
+    follow-redirects "^1.10.0"
 
 axobject-query@^2.1.2:
   version "2.2.0"
@@ -2996,6 +3044,13 @@ crypto-random-string@^2.0.0:
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"
   integrity sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
 
+css-box-model@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/css-box-model/-/css-box-model-1.2.1.tgz#59951d3b81fd6b2074a62d49444415b0d2b4d7c1"
+  integrity sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==
+  dependencies:
+    tiny-invariant "^1.0.6"
+
 css-color-keywords@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
@@ -3062,7 +3117,7 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-date-fns@^2.0.1:
+date-fns@2.15.0, date-fns@^2.0.1:
   version "2.15.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.15.0.tgz#424de6b3778e4e69d3ff27046ec136af58ae5d5f"
   integrity sha512-ZCPzAMJZn3rNUvvQIMlXhDr4A+Ar07eLeGsGREoWU19a3Pqf5oYa+ccd+B3F6XVtQY6HANMFdOQ8A+ipFnvJdQ==
@@ -3914,6 +3969,11 @@ follow-redirects@1.5.10:
   dependencies:
     debug "=3.1.0"
 
+follow-redirects@^1.10.0:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.1.tgz#d9114ded0a1cfdd334e164e6662ad02bfd91ff43"
+  integrity sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==
+
 forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
@@ -4251,7 +4311,7 @@ history@^4.9.0:
     tiny-warning "^1.0.0"
     value-equal "^1.0.1"
 
-hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0:
+hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -4357,12 +4417,12 @@ husky@^4.2.5:
     slash "^3.0.0"
     which-pm-runs "^1.0.0"
 
-i18next@^19.1.0:
-  version "19.6.3"
-  resolved "https://registry.yarnpkg.com/i18next/-/i18next-19.6.3.tgz#ce2346161b35c4c5ab691b0674119c7b349c0817"
-  integrity sha512-eYr98kw/C5z6kY21ti745p4IvbOJwY8F2T9tf/Lvy5lFnYRqE45+bppSgMPmcZZqYNT+xO0N0x6rexVR2wtZZQ==
+i18next@19.8.7:
+  version "19.8.7"
+  resolved "https://registry.yarnpkg.com/i18next/-/i18next-19.8.7.tgz#ef023e353974d1b1453e8b6331bd9fb7cba427df"
+  integrity sha512-ezo1gb7QO4OQ5gQCdZMUxopwQSoqpRp6whdEjm1grxMSmkGj1NJ+kYS0UQd4NnpPIVqsgqTQ2L2eqSQYQ+U3Fw==
   dependencies:
-    "@babel/runtime" "^7.10.1"
+    "@babel/runtime" "^7.12.0"
 
 iconv-lite@^0.6.2:
   version "0.6.2"
@@ -5442,6 +5502,11 @@ memoize-one@^5.0.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.1.1.tgz#047b6e3199b508eaec03504de71229b8eb1d75c0"
   integrity sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA==
+
+memoize-one@^5.1.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.2.1.tgz#8337aa3c4335581839ec01c3d594090cebe8f00e"
+  integrity sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==
 
 memoizee@^0.4.14:
   version "0.4.14"
@@ -6676,6 +6741,11 @@ qw@~1.0.1:
   resolved "https://registry.yarnpkg.com/qw/-/qw-1.0.1.tgz#efbfdc740f9ad054304426acb183412cc8b996d4"
   integrity sha1-77/cdA+a0FQwRCassYNBLMi5ltQ=
 
+raf-schd@^4.0.2:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/raf-schd/-/raf-schd-4.0.3.tgz#5d6c34ef46f8b2a0e880a8fcdb743efc5bfdbc1a"
+  integrity sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==
+
 randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
@@ -6692,6 +6762,19 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.2.8:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+react-beautiful-dnd@^13.0.0:
+  version "13.1.0"
+  resolved "https://registry.yarnpkg.com/react-beautiful-dnd/-/react-beautiful-dnd-13.1.0.tgz#ec97c81093593526454b0de69852ae433783844d"
+  integrity sha512-aGvblPZTJowOWUNiwd6tNfEpgkX5OxmpqxHKNW/4VmvZTNTbeiq7bA3bn5T+QSF2uibXB0D1DmJsb1aC/+3cUA==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+    css-box-model "^1.2.0"
+    memoize-one "^5.1.1"
+    raf-schd "^4.0.2"
+    react-redux "^7.2.0"
+    redux "^4.0.4"
+    use-memo-one "^1.1.1"
 
 react-datepicker@^3.1.3:
   version "3.1.3"
@@ -6729,7 +6812,7 @@ react-input-autosize@^2.2.2:
   dependencies:
     prop-types "^15.5.8"
 
-react-is@=16.13.1, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.9.0:
+react-is@=16.13.1, react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.9.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -6762,6 +6845,18 @@ react-redux@=7.2.0:
     loose-envify "^1.4.0"
     prop-types "^15.7.2"
     react-is "^16.9.0"
+
+react-redux@^7.2.0:
+  version "7.2.4"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.4.tgz#1ebb474032b72d806de2e0519cd07761e222e225"
+  integrity sha512-hOQ5eOSkEJEXdpIKbnRyl04LhaWabkDPV+Ix97wqQX3T3d2NQ8DUblNXXtNMavc7DpswyQM6xfaN4HQDKNY2JA==
+  dependencies:
+    "@babel/runtime" "^7.12.1"
+    "@types/react-redux" "^7.1.16"
+    hoist-non-react-statics "^3.3.2"
+    loose-envify "^1.4.0"
+    prop-types "^15.7.2"
+    react-is "^16.13.1"
 
 react-router-dom@=5.2.0:
   version "5.2.0"
@@ -6999,6 +7094,13 @@ redux@=4.0.5:
   dependencies:
     loose-envify "^1.4.0"
     symbol-observable "^1.2.0"
+
+redux@^4.0.0, redux@^4.0.4:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.1.0.tgz#eb049679f2f523c379f1aff345c8612f294c88d4"
+  integrity sha512-uI2dQN43zqLWCt6B/BMGRMY6db7TTY4qeHHfGeKb3EOhmOKjU3KdWvNLJyqaHRksv/ErdNH7cFZWg9jXtewy4g==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
 
 reflect-metadata@^0.1.13:
   version "0.1.13"
@@ -8014,7 +8116,7 @@ timers-ext@^0.1.5, timers-ext@^0.1.7:
     es5-ext "~0.10.46"
     next-tick "1"
 
-tiny-invariant@^1.0.2:
+tiny-invariant@^1.0.2, tiny-invariant@^1.0.6:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.1.0.tgz#634c5f8efdc27714b7f386c35e6760991d230875"
   integrity sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==
@@ -8358,6 +8460,11 @@ url-parse-lax@^1.0.0:
   integrity sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=
   dependencies:
     prepend-http "^1.0.1"
+
+use-memo-one@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/use-memo-one/-/use-memo-one-1.1.2.tgz#0c8203a329f76e040047a35a1197defe342fab20"
+  integrity sha512-u2qFKtxLsia/r8qG0ZKkbytbztzRb317XCkT7yP8wxL0tZ/CzK2G+WWie5vWvpyeP7+YoPIwbJoIHJ4Ba4k0oQ==
 
 util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
This commit is a part of AdminBro to AdminJS rebranding process.

BREAKING CHANGE: AdminBro has been rebranded to AdminJS. All package and repository names had been updated.

1. Update your dependencies to use new `adminjs` packages.
- `admin-bro` -> `adminjs` for the core package
- `@admin-bro/<package name>` -> `@adminjs/<package name>` for other modules
2. Update your custom CSS classes:
- `.admin-bro_<component name>` -> `.adminjs_<component name>` (example: `.adminjs_Box`)
3. Search your project for `admin-bro` occurrences - most likely they will have to be updated to `adminjs`