### PR TITLE
feat: allow registering admin entities inside their own module

### DIFF
--- a/src/admin-resource.module.ts
+++ b/src/admin-resource.module.ts
@@ -1,0 +1,45 @@
+import { Module, DynamicModule } from '@nestjs/common';
+import { ResourceWithOptions } from 'adminjs'
+
+import AdminResourceService from './admin-resource.service';
+
+/**
+ * Nest module which is responsible for admin resources
+ * 
+ * @summary Nest Module
+ * 
+ * @class
+ * @name module:@adminjs/nestjs~AdminResourceModule
+ * @alias AdminResourceModule
+ * @memberof module:@adminjs/nestjs
+ */
+@Module({})
+export class AdminResourceModule {
+  /** 
+   * Register resources
+   * 
+   * @param {(ResourceWithOptions | any)[]} resources
+   * @memberof module:@adminjs/nestjs~AdminResourceModule
+   * @method
+   * @name forFeature
+   * @example
+   * import { Module } from '@nestjs/common';
+   * import { AdminResourceModule } from '@adminjs/nestjs';
+   * import { User } from './user.entity';
+   * 
+   * \@Module({
+   *   imports: [
+   *     AdminResourceModule.forFeature([User]),
+   *   ],
+   * })
+   * export class UserModule {}
+   * 
+   */
+  public static forFeature(resources: (ResourceWithOptions | any)[]): DynamicModule {
+    AdminResourceService.add(resources)
+    
+    return {
+      module: AdminResourceModule,
+    };
+  }
+}

--- a/src/admin-resource.service.ts
+++ b/src/admin-resource.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@nestjs/common';
+import { ResourceWithOptions } from 'adminjs';
+
+@Injectable()
+class AdminResourceService {
+  private static resources: Set<ResourceWithOptions | any> = new Set();
+
+  public static add(resources: (ResourceWithOptions | any)[]) {
+    for (const resource of resources) {
+      if (AdminResourceService.resources.has(resource)) {
+        return;
+      }
+      AdminResourceService.resources.add(resource);
+    }
+  }
+
+  public static getResources() {
+    return Array.from(AdminResourceService.resources);
+  }
+}
+  
+export default AdminResourceService;

--- a/src/admin.module.ts
+++ b/src/admin.module.ts
@@ -8,6 +8,7 @@ import { AbstractLoader } from './loaders/abstract.loader'
 import { AdminModuleOptions } from './interfaces/admin-module-options.interface'
 import { AdminModuleFactory } from './interfaces/admin-module-factory.interface'
 import { CustomLoader } from './interfaces/custom-loader.interface'
+import AdminResourceService from './admin-resource.service'
 
 /**
  * Nest module which is responsible for an AdminJS integration
@@ -126,7 +127,13 @@ export class AdminModule implements OnModuleInit {
       return;
     }
 
-    const admin = new AdminJS(this.adminModuleOptions.adminJsOptions);
+    const forFeatureResources = AdminResourceService.getResources()
+
+    const adminJSOptions = forFeatureResources.length > 0
+      ? { ...this.adminModuleOptions.adminJsOptions, resources: forFeatureResources }
+      : this.adminModuleOptions.adminJsOptions
+
+    const admin = new AdminJS(adminJSOptions);
 
     const { httpAdapter } = this.httpAdapterHost;
     this.loader.register(admin, httpAdapter, { 

--- a/src/index.ts
+++ b/src/index.ts
@@ -213,6 +213,7 @@
 import * as NestJSPlugin from './admin.module'
 
 export * from './admin.module';
+export * from './admin-resource.module';
 export default NestJSPlugin;
 export * from './interfaces/admin-module-factory.interface';
 export * from './interfaces/admin-module-options.interface';


### PR DESCRIPTION
# What 
In order to fit better the NestJS modular architecture, this feature provides a way to register entities inside admin directly in the resource module instead of in the `app.module`. It also matches how the NestJS plugins for ORMs are coded by the NestJS team (like @nestjs/typeorm).

**This is not a breaking change**, it only adds another way to register resources. However, there are now 3 different ways to do this and it is not very well documented so maybe it would be wise to drop one. Personnaly, I really think registering resources with a `forFeature` method is the way to go.

# How
Here is an example of how to use this feature : 

in `user.module.ts` : 
```javascript
import { Module } from '@nestjs/common';

import { UserController } from './user.controller';
import { UserService } from './user.service';
import { TypeOrmModule } from '@nestjs/typeorm';
import { User } from './user.entity';
import { AdminResourceModule } from '@adminjs/nestjs';

@Module({
  imports: [
    TypeOrmModule.forFeature([User]),
    AdminResourceModule.forFeature([User]),
  ],
  controllers: [UserController],
  providers: [UserService],
  exports: [TypeOrmModule],
})
export class UserModule {}
```

in `app.module.ts` : 
```javascript
import { AdminModule } from 'adminnest';
import { User } from '@modules/user/user.entity';
import { Module } from '@nestjs/common';
import AdminJS from 'adminjs';
import { AppController } from './app.controller';
import { AppService } from './app.service';
import { Database, Resource } from '@adminjs/typeorm';
import { TypeOrmModule } from '@nestjs/typeorm';
import { UserModule } from '@modules/user/user.module';
import { dataSourceOptions } from './datasource.options';

AdminJS.registerAdapter({ Database, Resource });

@Module({
  imports: [
    TypeOrmModule.forRoot(dataSourceOptions),
    AdminModule.createAdmin({
      adminJsOptions: {
        rootPath: '/admin',
        resources: [User],
      },
    }),
    UserModule,
  ],
  controllers: [AppController],
  providers: [AppService],
})
export class AppModule {}
```