### PR TITLE
Call admin.watch after AdminJS initialization

### DIFF
--- a/src/admin.module.ts
+++ b/src/admin.module.ts
@@ -134,6 +134,7 @@ export class AdminModule implements OnModuleInit {
       : this.adminModuleOptions.adminJsOptions
 
     const admin = new AdminJS(adminJSOptions);
+    admin.watch();
 
     const { httpAdapter } = this.httpAdapterHost;
     this.loader.register(admin, httpAdapter, {


### PR DESCRIPTION
Otherwise components added via ComponentLoader won't get bundled in development.

This can be see in docs here https://docs.adminjs.co/ui-customization/writing-your-own-components#creating-custom-pages